### PR TITLE
Avoid double fetching of document drives on startup

### DIFF
--- a/src/hooks/useDocumentDriveServer.ts
+++ b/src/hooks/useDocumentDriveServer.ts
@@ -10,12 +10,10 @@ import {
     reducer,
 } from 'document-model-libs/document-drive';
 import { Document, Operation, utils } from 'document-model/document';
-import { atom, useAtom } from 'jotai';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useGetDocumentModel } from 'src/store/document-model';
 import { loadFile } from 'src/utils/file';
-
-export const documentDrivesAtom = atom<DocumentDriveDocument[]>([]);
+import { useDocumentDrives } from './useDocumentDrives';
 
 // TODO this should be added to the document model
 export interface SortOptions {
@@ -25,31 +23,13 @@ export interface SortOptions {
 export function useDocumentDriveServer(
     server: IDocumentDriveServer | undefined = window.electronAPI?.documentDrive
 ) {
-    const getDocumentModel = useGetDocumentModel();
-
-    const [documentDrives, setDocumentDrives] = useAtom(documentDrivesAtom);
-
-    async function fetchDocumentDrives() {
-        if (!server) {
-            return setDocumentDrives([]);
-        }
-        try {
-            const driveIds = await server?.getDrives();
-            const drives = await Promise.all(
-                driveIds.map(id => server.getDrive(id))
-            );
-            setDocumentDrives(drives);
-        } catch (error) {
-            console.error(error);
-            setDocumentDrives([]);
-        }
+    if (!server) {
+        throw new Error('Invalid Document Drive Server');
     }
 
-    useEffect(() => {
-        if (!documentDrives.length) {
-            fetchDocumentDrives();
-        }
-    }, []);
+    const getDocumentModel = useGetDocumentModel();
+
+    const [documentDrives, refreshDocumentDrives] = useDocumentDrives(server);
 
     async function openFile(drive: string, id: string) {
         const document = await server?.getDocument(drive, id);
@@ -85,7 +65,7 @@ export function useDocumentDriveServer(
 
         const newDrive = await server.addOperation(driveId, '', operation);
 
-        await fetchDocumentDrives();
+        await refreshDocumentDrives();
 
         if (!isDocumentDrive(newDrive)) {
             throw new Error('Received document is not a Document Drive');
@@ -285,7 +265,7 @@ export function useDocumentDriveServer(
             throw new Error(`Drive with id ${id} not found`);
         }
         await server.deleteDrive(id);
-        return fetchDocumentDrives();
+        return refreshDocumentDrives();
     }
 
     async function renameDrive(id: string, name: string) {

--- a/src/hooks/useDocumentDrives.ts
+++ b/src/hooks/useDocumentDrives.ts
@@ -1,0 +1,66 @@
+import { IDocumentDriveServer } from 'document-drive';
+import { DocumentDriveDocument } from 'document-model-libs/document-drive';
+import { atom, useAtom } from 'jotai';
+import { atomFamily } from 'jotai/utils';
+import { useMemo } from 'react';
+
+// map of DocumentDriveServer objects and their Document Drives
+const documentDrivesAtom = atom(
+    new Map<IDocumentDriveServer, DocumentDriveDocument[]>()
+);
+
+// creates a derived atom that encapsulates the Map of Document Drives
+const readWriteDocumentDrivesAtom = (server: IDocumentDriveServer) =>
+    useMemo(
+        () =>
+            atom(
+                get => get(documentDrivesAtom).get(server) ?? [],
+                (_get, set, newDrives: DocumentDriveDocument[]) => {
+                    set(documentDrivesAtom, map =>
+                        new Map(map).set(server, newDrives)
+                    );
+                }
+            ),
+        [server]
+    );
+
+// keeps track of document drives that have been initialized
+export const documentDrivesInitializedMapAtomFamily = atomFamily(() =>
+    atom(false)
+);
+
+// returns an array with the document drives of a
+// server and a method to fetch the document drives
+export function useDocumentDrives(server: IDocumentDriveServer) {
+    const [documentDrives, setDocumentDrives] = useAtom(
+        readWriteDocumentDrivesAtom(server)
+    );
+
+    async function refreshDocumentDrives() {
+        try {
+            const driveIds = await server.getDrives();
+            const drives = await Promise.all(
+                driveIds.map(id => server.getDrive(id))
+            );
+            setDocumentDrives(drives);
+        } catch (error) {
+            console.error(error);
+            setDocumentDrives([]);
+        }
+    }
+
+    // if the server has not been initialized then
+    // fetches the drives for the first time
+    const [isInitialized, setIsInitialized] = useAtom(
+        documentDrivesInitializedMapAtomFamily(server)
+    );
+    if (!isInitialized) {
+        setIsInitialized(true);
+        refreshDocumentDrives();
+    }
+
+    return useMemo(
+        () => [documentDrives, refreshDocumentDrives] as const,
+        [documentDrives]
+    );
+}


### PR DESCRIPTION
Fixes #30.

All components that use the `useDocumentDrivesServer` hook were triggering a document drives fetch request, resulting in multiple parallel requests on startup.