### PR TITLE
Update document-model 1.0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dependencies": {
         "@powerhousedao/design-system": "1.0.0-alpha.56",
         "document-drive": "^0.0.30",
-        "document-model": "^1.0.28",
+        "document-model": "^1.0.29",
         "electron-is-dev": "^2.0.0",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4562,10 +4562,10 @@ document-model-libs@^1.1.43:
   resolved "https://registry.yarnpkg.com/document-model-libs/-/document-model-libs-1.1.43.tgz#d12704c9faa700c27de38d6d47d577420d446676"
   integrity sha512-bDZTeBc0XVFP1hQ1sfcRVPGMrMS8tnLTsumLyGg7VeBf/yGJBAqRrEl5NSMmWBr9lVkdUKCVpHHFCIadB8NjBQ==
 
-document-model@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/document-model/-/document-model-1.0.28.tgz#0d129a4a1610667fc43a5df2cc73d91c5e813c00"
-  integrity sha512-bigF2MbWB594IJALqHYn5l7lx5WJntinHYPAMnN5UoVP1/BmEnmixGpLnTe9V5679IsFv4QPP402KXE7BiRm8g==
+document-model@^1.0.29:
+  version "1.0.29"
+  resolved "https://registry.yarnpkg.com/document-model/-/document-model-1.0.29.tgz#befdca50981511011d0fb194bbe0c313dd87cb88"
+  integrity sha512-CX3d3+aD6tbRD7y666k9UNMEGFKPTew44dgN5CBixEToAcOel3Ai9un24fiOFtiLCUYpJ8LAsxVOCWBeP+Jq5g==
   dependencies:
     immer "^10.0.3"
     json-stringify-deterministic "1.0.10"


### PR DESCRIPTION
## Description

Update document-model lib to v1.0.29 (this version includes the support for UNDO operations)

![2024-02-13 15 29 17](https://github.com/powerhouse-inc/document-model-electron/assets/20387722/156cf2ab-7904-4192-ada0-dc0d650f4960)
