### PR TITLE
fix: properly encode switchboard query

### DIFF
--- a/src/utils/getSwitchboardUrl.ts
+++ b/src/utils/getSwitchboardUrl.ts
@@ -111,7 +111,7 @@ const getQuery = (documentId: string, documentType: string) => {
         query = rwaQuery;
     }
 
-    return encodeURI(`query {
+    return encodeURIComponent(`query {
         document(id:"${documentId}") {
             name
             documentType


### PR DESCRIPTION
## Description:

- Use`encodeURIComponent` instead `encodeURI` when encoding switchboard query