### PR TITLE
Feat env editors

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_DISABLED_EDITORS=powerhouse/document-drive

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ jspm_packages/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
 .env.test
 
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    VITE_ENABLED_EDITORS: string;
+    VITE_DISABLED_EDITORS: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/src/hooks/useFeatureFlags/default-config.ts
+++ b/src/hooks/useFeatureFlags/default-config.ts
@@ -1,16 +1,22 @@
 export const FEATURE_FLAG_KEY_STORAGE = 'feature-flags-config';
 
+const ENABLED_EDITORS = import.meta.env.VITE_ENABLED_EDITORS || undefined;
+const enabledEditors = ENABLED_EDITORS?.split(',');
+
+const DISABLED_EDITORS = import.meta.env.VITE_DISABLED_EDITORS || undefined;
+const disabledEditors = DISABLED_EDITORS?.split(',');
+
 export interface FeatureFlag {
     editors: {
-        enabledEditors?: string | string[];
-        disabledEditors?: string | string[];
+        enabledEditors?: '*' | string[];
+        disabledEditors?: '*' | string[];
     };
 }
 
 const defaultConfig: FeatureFlag = {
     editors: {
-        enabledEditors: ['makerdao/rwa-portfolio'],
-        disabledEditors: undefined,
+        enabledEditors: ENABLED_EDITORS === '*' ? '*' : enabledEditors,
+        disabledEditors: DISABLED_EDITORS === '*' ? '*' : disabledEditors,
     },
 };
 

--- a/src/store/document-model.ts
+++ b/src/store/document-model.ts
@@ -48,31 +48,23 @@ export const useFilteredDocumentModels = () => {
     const { config } = useFeatureFlag();
     const { enabledEditors, disabledEditors } = config.editors;
 
-    if (typeof enabledEditors === 'string' && enabledEditors === '*') {
+    if (enabledEditors === '*') {
         return documentModels;
     }
 
-    if (typeof disabledEditors === 'string' && disabledEditors === '*') {
+    if (disabledEditors === '*') {
         return [];
     }
 
     if (disabledEditors) {
-        const disabledEditorsArray = Array.isArray(disabledEditors)
-            ? disabledEditors
-            : [disabledEditors];
-
         return documentModels.filter(
-            d => !disabledEditorsArray.includes(d.documentModel.id),
+            d => !disabledEditors.includes(d.documentModel.id),
         );
     }
 
     if (enabledEditors) {
-        const enabledEditorsArray = Array.isArray(enabledEditors)
-            ? enabledEditors
-            : [enabledEditors];
-
         return documentModels.filter(d =>
-            enabledEditorsArray.includes(d.documentModel.id),
+            enabledEditors.includes(d.documentModel.id),
         );
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
         "baseUrl": ".",
         "paths": {
             "@/assets": ["assets"]
-        }
+        },
+        "types": ["vite/client"]
     },
     "include": [
         "src", 


### PR DESCRIPTION
Makes available editors configurable with environment variables on build time.

Disable document drive by default as we don't support it as a normal document.