### PR TITLE
feat: added editor debug tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "dependencies": {
         "@powerhousedao/design-system": "1.0.0-alpha.69",
         "document-drive": "1.0.0-alpha.17",
-        "document-model": "^1.0.30",
+        "document-model": "^1.0.31",
         "electron-is-dev": "^2.0.0",
         "electron-squirrel-startup": "^1.0.0",
         "electron-store": "^8.1.0",

--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -54,11 +54,19 @@ export const DocumentEditor: React.FC<IProps> = ({
 
     function dispatch(action: BaseAction | Action) {
         _dispatch(action, operation => {
+            window.documentEditorDebugTools?.pushOperation(operation);
             onAddOperation(operation);
         });
     }
 
     useEffect(() => {
+        return () => {
+            window.documentEditorDebugTools?.clear();
+        };
+    }, []);
+
+    useEffect(() => {
+        window.documentEditorDebugTools?.setDocument(document);
         onChange?.(document);
     }, [document]);
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,11 +1,13 @@
 import type { ElectronAPI } from './preload';
 import type { IConnectCrypto } from './services/crypto';
+import { DocumentEditorDebugTools } from './utils/document-editor-debug-tools';
 export {};
 
 declare global {
     interface Window {
         electronAPI?: ElectronAPI;
         connectCrypto?: IConnectCrypto;
+        documentEditorDebugTools?: DocumentEditorDebugTools;
     }
 
     const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,5 +29,10 @@ import { createRoot } from 'react-dom/client';
 import App from './components/app';
 import './i18n';
 import './index.css';
+import { DocumentEditorDebugTools } from './utils/document-editor-debug-tools';
+
+if (import.meta.env.MODE === 'development') {
+    window.documentEditorDebugTools = new DocumentEditorDebugTools();
+}
 
 createRoot(document.getElementById('app')!).render(App);

--- a/src/utils/document-editor-debug-tools.ts
+++ b/src/utils/document-editor-debug-tools.ts
@@ -1,0 +1,67 @@
+import { Document, Operation, OperationScope } from 'document-model/document';
+
+export class DocumentEditorDebugTools {
+    private document: Document | undefined;
+    private operations: Operation[] = [];
+
+    constructor(document?: Document) {
+        if (document) {
+            this.document = document;
+        }
+    }
+
+    private operationsToTableObject(operations: Operation[]) {
+        return operations.map(op => ({
+            ...op,
+            input: JSON.stringify(op.input),
+        }));
+    }
+
+    public setDocument(document: Document) {
+        this.document = document;
+    }
+
+    public getDocument() {
+        return this.document;
+    }
+
+    public getOperations() {
+        return this.operations;
+    }
+
+    public pushOperation(operation: Operation) {
+        this.operations.push(operation);
+    }
+
+    public operationsTable() {
+        if (!this.document) {
+            console.warn('No document');
+        }
+        const ops = Object.values(this.document?.operations || {})
+            .flatMap(array => array)
+            .sort((a, b) => a.index - b.index);
+
+        console.table(this.operationsToTableObject(ops));
+    }
+
+    public scopeOperationsTable(scope: string) {
+        if (!this.document) {
+            console.warn('No document');
+        }
+        const ops = this.document?.operations[scope as OperationScope] || [];
+        console.table(this.operationsToTableObject(ops));
+    }
+
+    public operationsLog() {
+        console.log(this.operations);
+    }
+
+    public operationsLogTable() {
+        console.table(this.operationsToTableObject(this.operations));
+    }
+
+    public clear() {
+        this.operations = [];
+        this.document = undefined;
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5315,6 +5315,17 @@ document-model@^1.0.30:
     mime "^4.0.1"
     zod "^3.22.4"
 
+document-model@^1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/document-model/-/document-model-1.0.31.tgz#eac886edfe7b7630829a01147c9fa4b5e09a8750"
+  integrity sha512-E2SB1iNcKJfNWPjSCDFLnEFnA4HmwUF7oWwnXdX58KvryPyqTjkShIKkvbpyKYzyx54fsQid013hYkvKRVBuqw==
+  dependencies:
+    immer "^10.0.3"
+    json-stringify-deterministic "1.0.12"
+    jszip "^3.10.1"
+    mime "^4.0.1"
+    zod "^3.22.4"
+
 dot-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"


### PR DESCRIPTION
## Description:

- Added `documentEditorDebugTools` object

> Usage:
> `window.documentEditorDebugTools.operationsTable()`: renders document's operations in a table format
> `window.documentEditorDebugTools.scopeOperationsTable(scope: string)`: filters document's operations by the scope provided and renders the result in a table format
> `window.documentEditorDebugTools.operationsLog()`: renders all the operations dispatched for the current editor session (all dispatched operations are recorded, no matter if they were added or not to the document)
> `window.documentEditorDebugTools.operationsLogTable()`: same as previous method but in table format
> `window.documentEditorDebugTools.getDocument()`: returns the document object.


Consider that this dev tools and the document are only available when the editor is open and the app is running in dev mode.


![2024-03-11 12 38 56](https://github.com/powerhouse-inc/document-model-electron/assets/20387722/f9e27c3d-edc8-4691-b5d4-036f0e76476a)
