### PR TITLE
Allow dispatching simultaneous operations

### DIFF
--- a/src/components/editors.tsx
+++ b/src/components/editors.tsx
@@ -33,7 +33,7 @@ export type EditorComponent<
 export interface IProps extends EditorProps {
     onClose: () => void;
     onExport: () => void;
-    onAddOperation: (operation: Operation) => void;
+    onAddOperation: (operation: Operation) => Promise<void>;
     onOpenSwitchboardLink?: () => Promise<void>;
 }
 
@@ -61,10 +61,7 @@ export const DocumentEditor: React.FC<IProps> = ({
             action,
             operation => {
                 window.documentEditorDebugTools?.pushOperation(operation);
-
-                if (operation) {
-                    onAddOperation(operation);
-                }
+                onAddOperation(operation).catch(console.error);
             },
             onErrorCallback,
         );

--- a/src/hooks/useDocumentDriveServer.ts
+++ b/src/hooks/useDocumentDriveServer.ts
@@ -287,6 +287,26 @@ export function useDocumentDriveServer(
         return newDocument.document;
     }
 
+    async function addOperations(
+        driveId: string,
+        id: string,
+        operations: Operation[],
+    ) {
+        if (!server) {
+            throw new Error('Server is not defined');
+        }
+
+        const drive = documentDrives.find(
+            drive => drive.state.global.id === driveId,
+        );
+        if (!drive) {
+            throw new Error(`Drive with id ${driveId} not found`);
+        }
+
+        const newDocument = await server.addOperations(driveId, id, operations);
+        return newDocument.document;
+    }
+
     async function addDrive(drive: DriveInput) {
         const id = drive.global.id || utils.hashKey();
         drive = documentDriveUtils.createState(drive);
@@ -388,6 +408,7 @@ export function useDocumentDriveServer(
             renameNode,
             copyOrMoveNode,
             addOperation,
+            addOperations,
             getChildren,
             addDrive,
             addRemoteDrive,

--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -107,6 +107,9 @@ const Content = () => {
         if (!selectedDocument) {
             throw new Error('No document selected');
         }
+        if (!addOperation) {
+            throw new Error('No add operation function defined');
+        }
         return addOperation(operation);
     }
 

--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -107,7 +107,7 @@ const Content = () => {
         if (!selectedDocument) {
             throw new Error('No document selected');
         }
-        addOperation(operation);
+        return addOperation(operation);
     }
 
     function createDocument(documentModel: DocumentModel) {
@@ -120,8 +120,8 @@ const Content = () => {
         });
     }
 
-    async function exportDocument(document: Document) {
-        exportFile(document, getDocumentModel);
+    function exportDocument(document: Document) {
+        return exportFile(document, getDocumentModel);
     }
 
     const selectFolder = (item: TreeItem) => {
@@ -161,7 +161,7 @@ const Content = () => {
             : undefined;
 
         if (document.name !== '' && item && item.label !== document.name) {
-            renameNode(decodedDriveID, item.id, document.name);
+            return renameNode(decodedDriveID, item.id, document.name);
         }
     };
 

--- a/src/store/document-drive.ts
+++ b/src/store/document-drive.ts
@@ -79,9 +79,7 @@ export const useFileNodeDocument = (drive?: string, id?: string) => {
 
     async function addOperation(operation: Operation) {
         if (drive && id) {
-            const document = await _addOperation(drive, id, operation);
-            // TODO check new remote document vs local document
-            setSelectedDocument(document);
+            return _addOperation(drive, id, operation); // TODO deal with sync error
         }
     }
 


### PR DESCRIPTION
Ignores the resulting document when storing an operation from the editor.

Also added a debounce so that operations done quickly after each other are grouped into a single `addOperations` call.