### PR TITLE
feat: use default values if there is a missing key for feature flags

### DIFF
--- a/src/hooks/useFeatureFlags/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags/useFeatureFlags.ts
@@ -1,11 +1,15 @@
 import { useAtom } from 'jotai';
 import { featureFlagAtom } from './atom';
+import defaultConfig from './default-config';
 
 export const useFeatureFlag = () => {
     const [config, setConfig] = useAtom(featureFlagAtom);
 
     return {
-        config,
+        config: {
+            ...defaultConfig,
+            ...config,
+        },
         setConfig,
     };
 };


### PR DESCRIPTION
## Description:

- use default values if there is a missing key for feature flags