### PR TITLE
feat: allow url for file

### DIFF
--- a/src/components/modal/modals/CreateDocumentModal.tsx
+++ b/src/components/modal/modals/CreateDocumentModal.tsx
@@ -21,6 +21,7 @@ export interface CreateDocumentModalProps {
             | {
                   drive: string;
                   id: string;
+                  parentFolder: string | null;
               }
             | undefined
         >
@@ -67,6 +68,7 @@ export const CreateDocumentModal: React.FC<
             setSelectedFileNode?.({
                 drive: driveID,
                 id: node.id,
+                parentFolder: node.parentFolder,
             });
         }
     };

--- a/src/hooks/useDocumentDriveServer.ts
+++ b/src/hooks/useDocumentDriveServer.ts
@@ -121,7 +121,7 @@ export function useDocumentDriveServer(
             {
                 id,
                 name,
-                parentFolder,
+                parentFolder: parentFolder ?? null,
                 documentType,
 
                 document,

--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -81,7 +81,7 @@ const Content = () => {
     )?.state.global.nodes;
 
     const [selectedFileNode, setSelectedFileNode] = useState<
-        { drive: string; id: string } | undefined
+        { drive: string; id: string; parentFolder: string | null } | undefined
     >(undefined);
     const [selectedDocument, setSelectedDocument, addOperation] =
         useFileNodeDocument(decodedDriveID, selectedFileNode?.id);
@@ -144,9 +144,9 @@ const Content = () => {
                             setSelectedFileNode({
                                 drive: drive.state.global.id,
                                 id: node.id,
+                                parentFolder: node.parentFolder,
                             });
                         }
-                        break;
                     }
                     path.push(encodeID(node.id));
 
@@ -200,7 +200,9 @@ const Content = () => {
                 setSelectedFileNode({
                     drive: decodedDriveID,
                     id: fileNode.id,
+                    parentFolder: fileNode.parentFolder,
                 });
+                navigateToItemId(fileNode.id);
             }
         });
     }, [selectedPath]);
@@ -317,7 +319,12 @@ const Content = () => {
                     >
                         <DocumentEditor
                             document={selectedDocument}
-                            onClose={() => setSelectedFileNode(undefined)}
+                            onClose={() => {
+                                navigateToItemId(
+                                    selectedFileNode.parentFolder ?? driveID,
+                                );
+                                setSelectedFileNode(undefined);
+                            }}
                             onChange={onDocumentChangeHandler}
                             onExport={() => exportDocument(selectedDocument)}
                             onAddOperation={handleAddOperation}
@@ -352,9 +359,15 @@ const Content = () => {
                                     drive={decodedDriveID}
                                     path={selectedPath || ''}
                                     onFolderSelected={onFolderSelectedHandler}
-                                    onFileSelected={(drive, id) =>
-                                        setSelectedFileNode({ drive, id })
-                                    }
+                                    onFileSelected={(drive, id) => {
+                                        setSelectedFileNode({
+                                            drive,
+                                            id,
+                                            parentFolder:
+                                                selectedFolder?.id ?? null,
+                                        });
+                                        navigateToItemId(id);
+                                    }}
                                     onFileDeleted={deleteNode}
                                 />
                             </div>


### PR DESCRIPTION
currently we do not allow linking directly to files, only drives and directories. I have here minimal changes to allow linking to files as well. I do not know why this feature was not initially set up in this way, so I hope my changes are not going to introduce new bugs. 

Please take a look and let me know if there is other logic that this code affects that I did not see. There could also be side effects I am not aware of.